### PR TITLE
Add Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,12 @@ jobs:
       - image: docker:18.01-git
     steps:
       - checkout
-      - setup_remote_docker:
-          reusable: true
-      - run:
-          name: Validate the docker version
-          command: docker version
+      - setup_remote_docker
       - run:
           name: Build
-          command: docker build -t mythmon/identicons:$CIRCLE_SHA1 .
+          command: |
+            docker build --target build --tag identicons-build .
+            docker build --target production --tag mythmon/identicons:$CIRCLE_SHA1 .
       - run:
           name: Test
-          command: docker run mythmon/identicons:$CIRCLE_SHA1 cargo test
+          command: docker run identicons-build cargo test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: docker:18.01-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          reusable: true
+      - run:
+          name: Validate the docker version
+          command: docker version
+      - run:
+          name: Build
+          command: docker build -t mythmon/identicons:$CIRCLE_SHA1 .
+      - run:
+          name: Test
+          command: docker run mythmon/identicons:$CIRCLE_SHA1 cargo test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
             docker build --target production --tag mythmon/identicons:$CIRCLE_SHA1 .
       - run:
           name: Test
-          command: docker run identicons-build cargo test
+          command: docker run identicons-build cargo test --release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: docker:18.01-git
+    branches:
+      ignore:
+        - staging.tmp
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,6 @@ jobs:
   build:
     docker:
       - image: docker:18.01-git
-    branches:
-      ignore:
-        - staging.tmp
     steps:
       - checkout
       - setup_remote_docker
@@ -13,7 +10,59 @@ jobs:
           name: Build
           command: |
             docker build --target build --tag identicons-build .
-            docker build --target production --tag mythmon/identicons:$CIRCLE_SHA1 .
+            docker build --target production --tag identicons-prod .
       - run:
           name: Test
           command: docker run identicons-build cargo test --release
+      - run:
+          filters:
+            branches:
+              only: master
+          name: Save docker image for deploy
+          command: |
+            mkdir -p docker-cache
+            docker save -o docker-cache/identicons-prod.tar identicons-prod
+      - save_cache:
+          key: docker-cache-v1-{{ .Revision }}
+          paths:
+            - docker-cache
+
+  deploy:
+    docker:
+      - image: google/cloud-sdk:183.0.0
+    working_directory: /tmp/identicons
+    steps:
+      - run:
+          name: Authenticate to GAE
+          command: |
+            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > gcloud-service-key.json
+            gcloud auth activate-service-account --key-file=gcloud-service-key.json
+            gcloud config set project identicons
+
+      - restore_cache:
+          key: docker-cache-v1-{{ .Revision }}
+
+      - run:
+          name: Load docker image from build step
+          command: |
+            docker load < docker-cache/identicons-prod.tar
+            docker tag identicons-prod gcr.io/identicons/$CIRCLE_BRANCH:latest
+
+      - run:
+          name: Upload docker image to GCloud
+          command: gcloud docker -- push gcr.io/identicons/$CIRCLE_BRANCH:latest
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: staging.tmp
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cargo build --release
 # ----------
 
 # Create a new stage with a minimal image
-FROM debian:jessie-slim
+FROM debian:jessie-slim as production
 WORKDIR /app
 
 # Copies the binary from the "build" stage to the current stage

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "ci/circleci: build",
+]


### PR DESCRIPTION
- [x] CircleCI
  - [x] "Tests" (even though no tests exist, still run `cargo test`)
  - ~[ ] Clippy~ Only available on Rust Nightly
  - ~[ ] Lint~ I can't find a linter besides rustfmt, and rustfmt only works on Rust Nightly
  - ~[ ] Layer caching~ this is a premium feature on CircleCI 2.0
- [x] Bors
- [x] Auto deploy to GAE
  - [x] Upload image to gcr.io
  - [x] Deploy service