### PR TITLE
Add `#![deny(missing_docs)]`

### DIFF
--- a/src/icons/mod.rs
+++ b/src/icons/mod.rs
@@ -1,3 +1,5 @@
+//! Generating identicons.
+
 extern crate rand;
 
 mod data;
@@ -26,6 +28,7 @@ impl<R: rand::Rng> RngExt for R {
     }
 }
 
+/// An RGB color.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Color {
     /// Red component
@@ -37,10 +40,12 @@ pub struct Color {
 }
 
 impl Color {
+    /// Create the black color.
     pub fn black() -> Self {
         Self { r: 0, g: 0, b: 0 }
     }
 
+    /// Create the white color.
     pub fn white() -> Self {
         Self { r: 255, g: 255, b: 255 }
     }
@@ -55,10 +60,12 @@ impl Color {
         format!("rgb({},{},{})", self.r, self.g, self.b)
     }
 
+    /// Get this color's luminance.
     pub fn luminance(&self) -> f32 {
         0.2126 * self.r as f32 + 0.7152 * self.g as f32 + 0.0722 * self.b as f32
     }
 
+    /// Does this color contrast well with that other color?
     pub fn contrasts_well(&self, other: &Self) -> bool {
         (self.luminance() - other.luminance()).abs() > 75.0
     }

--- a/src/icons/shapes.rs
+++ b/src/icons/shapes.rs
@@ -2,18 +2,27 @@ extern crate rand;
 
 use super::{data, Color};
 
+/// A shape.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ShapeType {
+    /// A polygon of `n` sides.
     Polygon(u8),
+    /// A circle.
     Circle,
 }
 
+/// A description of a shape icon.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ShapeIconData {
+    /// The emoji to overlay on the icon.
     pub emoji: char,
+    /// The icon's shape.
     pub shape: ShapeType,
+    /// The icon's fill color.
     pub fill_color: Color,
+    /// The icon's border color.
     pub border_color: Color,
+    /// The offset of the icon.
     pub offset: f32,
 }
 

--- a/src/icons/shields.rs
+++ b/src/icons/shields.rs
@@ -2,22 +2,36 @@ extern crate rand;
 
 use super::{data, Color, RngExt};
 
+/// A description of a treatment for a shield.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ShieldIconTreatment {
+    /// A single, solid shield color, aka no treatment.
     SingleColor,
+
+    /// A treatment that results in a two-color shield pattern, by applying
+    /// another color at an angle.
     TwoColor {
+        /// The color of the pattern.
         pattern_color: Color,
+        /// The treatment's angle.
         angle: u16,
     },
+
+    /// A treatment that results in a two-color striped shield pattern.
     Stripes {
+        /// The color of the strips we are adding.
         pattern_color: Color,
+        /// The strip's stride.
         stride: f32,
+        /// X coordinates for the stripes.
         stripe_xs: Vec<f32>,
+        /// Angle of the stripes.
         angle: u16,
     },
 }
 
+/// A description of a shield icon.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ShieldIconData {
     treatment: ShieldIconTreatment,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+//! A Rust crate for generating identicons.
+//!
+//! Identicons are deterministic yet unpredictable icons that can be used as
+//! avatars or other visual identifiers.
+//!
+//! * Deterministic: given the same input, you'll always get the same identicon
+//! back out.
+//!
+//! * Unpredictable: similar-but-just-barely-different inputs give back
+//! radically different identicons.
+
+#![deny(missing_docs)]
+
 extern crate iron;
 extern crate rand;
 extern crate router;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,5 @@
+//! A server that serves up identicons.
+
 extern crate iron;
 extern crate rand;
 extern crate router;
@@ -17,6 +19,7 @@ use rand::{Rng, SeedableRng};
 
 use super::icons::{Color, ShieldIconData, ShapeIconData, ShapeType};
 
+/// Make the icon server.
 pub fn make_icon_server() -> Iron<Chain> {
     let mut router = Router::new();
     router.get("/", index, "index");


### PR DESCRIPTION
This is a nice touch for anyone trying to use your APIs without looking at the source (for example, from rustdoc's generated documentation).